### PR TITLE
Fix incorrect capitalization/camelCase in page titles

### DIFF
--- a/Language/Structure/Control Structure/doWhile.adoc
+++ b/Language/Structure/Control Structure/doWhile.adoc
@@ -1,5 +1,5 @@
 ---
-title: do...While
+title: do...while
 categories: [ "Structure" ]
 subCategories: [ "Control Structure" ]
 ---

--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -1,5 +1,5 @@
 ---
-title: switchCase
+title: switch...case
 categories: [ "Structure" ]
 subCategories: [ "Control Structure" ]
 ---

--- a/Language/Variables/Data Types/unsignedChar.adoc
+++ b/Language/Variables/Data Types/unsignedChar.adoc
@@ -1,5 +1,5 @@
 ---
-title: unsignedChar
+title: unsigned char
 categories: [ "Variables" ]
 subCategories: [ "Data Types" ]
 ---

--- a/Language/Variables/Data Types/unsignedInt.adoc
+++ b/Language/Variables/Data Types/unsignedInt.adoc
@@ -1,5 +1,5 @@
 ---
-title: unsignedInt
+title: unsigned int
 categories: [ "Variables" ]
 subCategories: [ "Data Types" ]
 ---

--- a/Language/Variables/Data Types/unsignedLong.adoc
+++ b/Language/Variables/Data Types/unsignedLong.adoc
@@ -1,5 +1,5 @@
 ---
-title: unsignedLong
+title: unsigned long
 categories: [ "Variables" ]
 subCategories: [ "Data Types" ]
 ---


### PR DESCRIPTION
These page titles did not match their capitalization/spelling in code usage.

See: https://github.com/arduino/reference-en/pull/283