### PR TITLE
Add missing closing brace to Keyboard.press() example code

### DIFF
--- a/Language/Functions/USB/Keyboard/keyboardPress.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPress.adoc
@@ -80,6 +80,7 @@ void loop() {
   Keyboard.releaseAll();
   // Warte, bis sich das Fenster öffnet:
   delay(1000);
+}
 ----
 
 --


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-de/issues/126