### PR TITLE
Wrap examples properly in Serial.print()

### DIFF
--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -16,20 +16,20 @@ title: Serial.print()
 === Description
 Prints data to the serial port as human-readable ASCII text. This command can take many forms. Numbers are printed using an ASCII character for each digit. Floats are similarly printed as ASCII digits, defaulting to two decimal places. Bytes are sent as a single character. Characters and strings are sent as is. For example-
 
-* `Serial.print(78) gives "78"` +
-* `Serial.print(1.23456) gives "1.23"` +
-* `Serial.print('N') gives "N"` +
-* `Serial.print("Hello world.") gives "Hello world." `
+* `Serial.print(78)` gives "78" +
+* `Serial.print(1.23456)` gives "1.23" +
+* `Serial.print('N')` gives "N" +
+* `Serial.print("Hello world.")` gives "Hello world." 
 
 An optional second parameter specifies the base (format) to use; permitted values are `BIN(binary, or base 2)`, `OCT(octal, or base 8)`, `DEC(decimal, or base 10)`, `HEX(hexadecimal, or base 16)`. For floating point numbers, this parameter specifies the number of decimal places to use. For example-
 
-* `Serial.print(78, BIN) gives "1001110"` +
-* `Serial.print(78, OCT) gives "116"` +
-* `Serial.print(78, DEC) gives "78"` +
-* `Serial.print(78, HEX) gives "4E"` +
-* `Serial.println(1.23456, 0) gives "1"` +
-* `Serial.println(1.23456, 2) gives "1.23"` +
-* `Serial.println(1.23456, 4) gives "1.2346"`
+* `Serial.print(78, BIN)` gives "1001110" +
+* `Serial.print(78, OCT)` gives "116" +
+* `Serial.print(78, DEC)` gives "78" +
+* `Serial.print(78, HEX)` gives "4E" +
+* `Serial.println(1.23456, 0)` gives "1" +
+* `Serial.println(1.23456, 2)` gives "1.23" +
+* `Serial.println(1.23456, 4)` gives "1.2346"
 
 You can pass flash-memory based strings to Serial.print() by wrapping them with F(). For example:
 


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-de/issues/123