### PR TITLE
Revert incorrect capitalizations in string reference page

### DIFF
--- a/Language/Variables/Data Types/string.adoc
+++ b/Language/Variables/Data Types/string.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Data Types" ]
 
 [float]
 === Description
-Text strings can be represented in two ways. you can use the String data type, which is part of the core as of version 0019, or you can make a string out of an array of type char and null-terminate it. This page described the latter method. For more details on the String object, which gives you more functionality at the cost of more memory, see the link:../stringobject[String object] page.
+Text strings can be represented in two ways. you can use the string data type, which is part of the core as of version 0019, or you can make a string out of an array of type char and null-terminate it. This page described the latter method. For more details on the string object, which gives you more functionality at the cost of more memory, see the link:../stringobject[string object] page.
 [%hardbreaks]
 
 [float]


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-de/issues/117