### PR TITLE
Declare counter variable in for statements

### DIFF
--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -58,7 +58,7 @@ Der folgende Code springt aus der `for`-Schleife, wenn der Sensorwert den Thresh
 [source,arduino]
 ----
 // Iteriere über die Zahlen von 0 bis 255
-for (x = 0; x < 255; x ++) {
+for (int x = 0; x < 255; x ++) {
   // Schreibe auf den LED-Pin
   analogWrite(PWMpin, x);
   // Lies den Sensorwert ein

--- a/Language/Structure/Control Structure/continue.adoc
+++ b/Language/Structure/Control Structure/continue.adoc
@@ -58,7 +58,7 @@ Der Code schreibt die Werte von 0 bis 255 auf den LED-Pin, aber überspringt Wer
 [source,arduino]
 ----
 // Iteriere über die Werte von 0 bis 255
-for (x = 0; x <= 255; x ++) {
+for (int x = 0; x <= 255; x ++) {
   // Springe bei den Werten zwischen 40 und 120 weiter
   if (x > 40 && x < 120){
     continue;

--- a/Language/Variables/Data Types/array.adoc
+++ b/Language/Variables/Data Types/array.adoc
@@ -66,8 +66,7 @@ Arrays are often manipulated inside for loops, where the loop counter is used as
 
 [source,arduino]
 ----
-int i;
-for (i = 0; i < 5; i = i + 1) {
+for (byte i = 0; i < 5; i = i + 1) {
   Serial.println(myPins[i]);
 }
 ----

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -75,7 +75,6 @@ const PROGMEM  uint16_t charSet[]  = { 65000, 32796, 16843, 10, 11234};
 const char signMessage[] PROGMEM  = { "I AM PREDATOR, UNSEEN COMBATANT. CREATED BY THE UNITED STATES DEPART"};
 
 unsigned int displayInt; // Rückgabewert der Funktion zum Auslesen der Daten
-int k; // Definiere eine Zählervariable
 char myChar; // Definiere einen Char, um diesen zu bearbeiten
 
 void setup() {
@@ -84,7 +83,7 @@ void setup() {
 
   // Setup code:
   // Lies einen 2-Byte-Int
-  for (k = 0; k < 5; k++) {
+  for (byte k = 0; k < 5; k++) {
     displayInt = pgm_read_word_near(charSet + k); // Lies den charSet-Wert wieder aus dem Flash-/Programm-Speicher
     Serial.println(displayInt); // Gib den gelesenen Wert aus
   }
@@ -92,7 +91,7 @@ void setup() {
   Serial.println(); // Schreibe eine neue Zeile
 
   // Lies einen Char
-  for (k = 0; k < strlen_P(signMessage); k++) {
+  for (byte k = 0; k < strlen_P(signMessage); k++) {
     myChar =  pgm_read_byte_near(signMessage + k); // Lies den signMessage-Wert wieder aus dem Flash-/Programm-Speicher
     Serial.print(myChar); // Gib den gelesenen Wert aus
   }

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -56,7 +56,6 @@ Das Programm gibt einen Text zeichenweise aus. Versuche, den Text zu ändern, da
 ----
 // Definiere Text und Zählervariable
 char myStr[] = "this is a test";
-int i;
 
 void setup() {
   // Initialisiere seriellen Port
@@ -65,7 +64,7 @@ void setup() {
 
 void loop() {
   // Laufe über das Array (den String), egal, wie lange dieser ist
-  for (i = 0; i < sizeof(myStr) - 1; i++) {
+  for (byte i = 0; i < sizeof(myStr) - 1; i++) {
 	// Gib die Zeichennummer als Dezimalzahl aus
     Serial.print(i, DEC);
 	// Gib ein Gleichheitszeichen aus
@@ -88,7 +87,7 @@ void loop() {
 ----
 int myValues[] = {123, 456, 789};
 // Diese for-Schleife funktioniert ordnungsgemäß mit einem Array eines beliebigen Typs und jeder Größe
-for (i = 0; i < (sizeof(myValues)/sizeof(myValues[0])); i++) {
+for (byte i = 0; i < (sizeof(myValues)/sizeof(myValues[0])); i++) {
   // Tue etwas mit myValues[i]
 }
 ----


### PR DESCRIPTION
Declaring the counter variable outside the for statement is done very rarely in actual programming, and only when there is a use for that variable outside the scope of the for loop (which is not the case here). I don't see any value in declaring the variable outside the statement in the example code, as it only teaches bad programming. In some cases, the example code snippets didn't even contain a declaration and so would not compile if copied into a sketch.

Fixes https://github.com/arduino/reference-de/issues/218