### PR TITLE
Fix link to PitchFollower tutorial

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -80,7 +80,7 @@ Wenn du verschiedene Töne auf mehreren Pins spielen willst, musst du zunächst 
 
 [role="example"]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Töne^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Tonleiter^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/tonePitchFollower[Tonleiter^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/Tone3[Einfaches Keyboard^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/Tone4[Mehrere Töne^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/PWM[PWM^]


### PR DESCRIPTION
Previously, the link pointed to the ToneMelody tutorial, which already has a link on the tone reference page.

Fixes https://github.com/arduino/reference-de/issues/221