### PR TITLE
Fix formatting of example code

### DIFF
--- a/AsciiDoc_sample/AsciiDoc_Dictionary/AsciiDoc_Template-Dictionary.adoc
+++ b/AsciiDoc_sample/AsciiDoc_Dictionary/AsciiDoc_Template-Dictionary.adoc
@@ -105,8 +105,8 @@ This is `code` in a sentence +
 This can be a lot more code 
 [source,arduino]
 ----
-for (int 1; i<=99; i++) {
-	Serial.println('We want more code!');
+for (int i = 0; i <= 99; i++) {
+  Serial.println('We want more code!');
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -58,7 +58,7 @@ Der folgende Code springt aus der `for`-Schleife, wenn der Sensorwert den Thresh
 [source,arduino]
 ----
 // Iteriere über die Zahlen von 0 bis 255
-for (int x = 0; x < 255; x ++) {
+for (int x = 0; x < 255; x++) {
   // Schreibe auf den LED-Pin
   analogWrite(PWMpin, x);
   // Lies den Sensorwert ein

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -69,10 +69,10 @@ Das folgende Code-Fragment zeigt, wie ein unsigned chars (bytes) und ints (2 byt
 [source,arduino]
 ----
 // Speichere einige unsigned ints
-const PROGMEM  uint16_t charSet[]  = { 65000, 32796, 16843, 10, 11234};
+const PROGMEM uint16_t charSet[] = { 65000, 32796, 16843, 10, 11234};
 
 // Speichere einen String
-const char signMessage[] PROGMEM  = { "I AM PREDATOR, UNSEEN COMBATANT. CREATED BY THE UNITED STATES DEPART"};
+const char signMessage[] PROGMEM = {"I AM PREDATOR, UNSEEN COMBATANT. CREATED BY THE UNITED STATES DEPART"};
 
 unsigned int displayInt; // Rückgabewert der Funktion zum Auslesen der Daten
 char myChar; // Definiere einen Char, um diesen zu bearbeiten
@@ -92,7 +92,7 @@ void setup() {
 
   // Lies einen Char
   for (byte k = 0; k < strlen_P(signMessage); k++) {
-    myChar =  pgm_read_byte_near(signMessage + k); // Lies den signMessage-Wert wieder aus dem Flash-/Programm-Speicher
+    myChar = pgm_read_byte_near(signMessage + k); // Lies den signMessage-Wert wieder aus dem Flash-/Programm-Speicher
     Serial.print(myChar); // Gib den gelesenen Wert aus
   }
 


### PR DESCRIPTION
Fix formatting issues which were not covered by the auto format.

Fix formatting issues in AsciiDoc_Template-Dictionary.adoc, which I accidentally skipped during the auto format.

Fixes https://github.com/arduino/reference-de/issues/222