### PR TITLE
Use a single space after period

### DIFF
--- a/Language/Variables/Data Types/int.adoc
+++ b/Language/Variables/Data Types/int.adoc
@@ -65,7 +65,7 @@ void loop() {
 
 [float]
 === Notes and Warnings
-When signed variables are made to exceed their maximum or minimum capacity they _overflow_.  The result of an overflow is unpredictable so this should be avoided.  A typical symptom of an overflow is the variable "rolling over" from its maximum capacity to its minimum or vice versa, but this is not always the case.  If you want this behavior, use link:../unsignedint/[unsigned int].
+When signed variables are made to exceed their maximum or minimum capacity they _overflow_. The result of an overflow is unpredictable so this should be avoided. A typical symptom of an overflow is the variable "rolling over" from its maximum capacity to its minimum or vice versa, but this is not always the case. If you want this behavior, use link:../unsignedint/[unsigned int].
 
 
 --


### PR DESCRIPTION
Following the standard established by the reference sample pages.

Fixes https://github.com/arduino/reference-de/issues/223