### PR TITLE
Update links to tone tutorials

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -79,10 +79,10 @@ Wenn du verschiedene Töne auf mehreren Pins spielen willst, musst du zunächst 
 * #LANGUAGE# link:../Analog%20IO/analogWrite.adoc[analogWrite()]
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Töne^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/toneMelody[Töne^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/tonePitchFollower[Tonleiter^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone3[Einfaches Keyboard^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone4[Mehrere Töne^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/toneKeyboard[Einfaches Keyboard^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/toneMultiple[Mehrere Töne^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/PWM[PWM^]
 
 --


### PR DESCRIPTION
The tone tutorial links use outdated URLs that must redirect to the current URLs. It's better to point the links directly to the correct URL.

Fixes https://github.com/arduino/reference-de/issues/232