### PR TITLE
Remove the term "Built-in" from the String tutorials link text

### DIFF
--- a/Language/Variables/Data Types/String/Functions/c_str.adoc
+++ b/Language/Variables/Data Types/String/Functions/c_str.adoc
@@ -53,6 +53,6 @@ A pointer to the C-style version of the invoking String.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/charAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/charAt.adoc
@@ -56,6 +56,6 @@ The n'th character of the String.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/compareTo.adoc
+++ b/Language/Variables/Data Types/String/Functions/compareTo.adoc
@@ -60,6 +60,6 @@ Compares two Strings, testing whether one comes before or after the other, or wh
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/concat.adoc
+++ b/Language/Variables/Data Types/String/Functions/concat.adoc
@@ -57,6 +57,6 @@ Appends the parameter to a String.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/endsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/endsWith.adoc
@@ -58,6 +58,6 @@ Tests whether or not a String ends with the characters of another String.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/equals.adoc
+++ b/Language/Variables/Data Types/String/Functions/equals.adoc
@@ -55,6 +55,6 @@ Compares two Strings for equality. The comparison is case-sensitive, meaning the
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
@@ -55,6 +55,6 @@ Compares two strings for equality. The comparison is not case-sensitive, meaning
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/getBytes.adoc
+++ b/Language/Variables/Data Types/String/Functions/getBytes.adoc
@@ -57,6 +57,6 @@ None
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/indexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/indexOf.adoc
@@ -59,6 +59,6 @@ The index of val within the String, or -1 if not found.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
@@ -59,6 +59,6 @@ The index of val within the String, or -1 if not found.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/length.adoc
+++ b/Language/Variables/Data Types/String/Functions/length.adoc
@@ -54,6 +54,6 @@ The length of the String in characters.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/remove.adoc
+++ b/Language/Variables/Data Types/String/Functions/remove.adoc
@@ -69,6 +69,6 @@ greeting.remove(2, 2);  // greeting now contains "heo"
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/replace.adoc
+++ b/Language/Variables/Data Types/String/Functions/replace.adoc
@@ -58,6 +58,6 @@ None
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -84,7 +84,7 @@ void loop() {
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/setCharAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/setCharAt.adoc
@@ -58,6 +58,6 @@ None
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/startsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/startsWith.adoc
@@ -55,6 +55,6 @@ Tests whether or not a String starts with the characters of another String.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/substring.adoc
+++ b/Language/Variables/Data Types/String/Functions/substring.adoc
@@ -59,6 +59,6 @@ The substring.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toCharArray.adoc
+++ b/Language/Variables/Data Types/String/Functions/toCharArray.adoc
@@ -57,6 +57,6 @@ None
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toDouble.adoc
+++ b/Language/Variables/Data Types/String/Functions/toDouble.adoc
@@ -56,6 +56,6 @@ If no valid conversion could be performed because the String doesn't start with 
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toFloat.adoc
+++ b/Language/Variables/Data Types/String/Functions/toFloat.adoc
@@ -56,6 +56,6 @@ If no valid conversion could be performed because the string doesn't start with 
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toInt.adoc
+++ b/Language/Variables/Data Types/String/Functions/toInt.adoc
@@ -56,6 +56,6 @@ If no valid conversion could be performed because the string doesn't start with 
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
@@ -54,6 +54,6 @@ None
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
@@ -53,6 +53,6 @@ None
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/trim.adoc
+++ b/Language/Variables/Data Types/String/Functions/trim.adoc
@@ -54,6 +54,6 @@ None
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/append.adoc
+++ b/Language/Variables/Data Types/String/Operators/append.adoc
@@ -55,6 +55,6 @@ None
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/comparison.adoc
+++ b/Language/Variables/Data Types/String/Operators/comparison.adoc
@@ -58,6 +58,6 @@ The nth char of the string. Same as charAt().
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/concatenation.adoc
+++ b/Language/Variables/Data Types/String/Operators/concatenation.adoc
@@ -55,6 +55,6 @@ new String that is the combination of the original two Strings.
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/differentFrom.adoc
+++ b/Language/Variables/Data Types/String/Operators/differentFrom.adoc
@@ -57,6 +57,6 @@ myString != myString2
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/elementAccess.adoc
+++ b/Language/Variables/Data Types/String/Operators/elementAccess.adoc
@@ -59,6 +59,6 @@ The nth char of the String. Same as charAt().
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/greaterThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThan.adoc
@@ -58,6 +58,6 @@ myString > myString2
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
@@ -59,6 +59,6 @@ myString >= myString2
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/lessThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThan.adoc
@@ -58,6 +58,6 @@ myString < myString2
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
@@ -59,6 +59,6 @@ myString <= myString2
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/stringObject.adoc
+++ b/Language/Variables/Data Types/stringObject.adoc
@@ -140,7 +140,7 @@ String stringOne =  String(5.698, 3);                     // using a float and t
 * #LANGUAGE# link:../string/operators/differentfrom[!= (different from)]
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[String Tutorials^]
 
 
 // SEE ALSO SECTION STARTS


### PR DESCRIPTION
I don't think the average Language Reference user will be familiar with the term "Built-in" (it's the term for the example sketches bundled with the Arduino IDE) so I think this could cause confusion. It doesn't really add anything of value to the link text so there's no reason for it to be there.

Fixes https://github.com/arduino/reference-de/issues/234