### PR TITLE
Remove leftover English fragment from the shiftOut() example description

### DIFF
--- a/Language/Functions/Advanced IO/shiftOut.adoc
+++ b/Language/Functions/Advanced IO/shiftOut.adoc
@@ -59,8 +59,6 @@ Nichts
 // Describe what the example code is all about and add relevant code   ►►►►► THIS SECTION IS MANDATORY ◄◄◄◄◄
 Für eingebaute Schaltkreise beachte das http://arduino.cc/en/Tutorial/ShiftOut[Tutorial, wie man ein 74HC595 Shift-Register verwendet].
 
-For accompanying circuit, see the
-
 [source,arduino]
 ----
 //**************************************************************//


### PR DESCRIPTION
The description was translated, but a fragment of the English text was left behind.