### PR TITLE
Fix heading markup in array reference page

### DIFF
--- a/Language/Variables/Data Types/array.adoc
+++ b/Language/Variables/Data Types/array.adoc
@@ -14,7 +14,7 @@ subCategories: [ "Datentypen" ]
 === Beschreibung
 Ein Array ist eine Sammlung von Variablen, auf die mit einer Indexnummer zugegriffen wird.
 Arrays in der Programmiersprache C ++, in der Arduino-Skizzen geschrieben sind, sind zwar kompliziert, aber die Verwendung einfacher Arrays ist relativ unkompliziert.
-
+[float]
 === Array erstellen / deklarieren
 
 Alle folgenden Methoden sind gültige Methoden zum Erstellen (Deklarieren) eines Arrays.


### PR DESCRIPTION
### Previous to this change:

![before](https://user-images.githubusercontent.com/8572152/57121486-dde0da00-6d2c-11e9-9a5a-f429a8c12dbe.png)

---

### How it should be formatted:

![after](https://user-images.githubusercontent.com/8572152/57121495-e6d1ab80-6d2c-11e9-89ad-0e423f5b58cf.png)
