### PR TITLE
Fix formatting of == reference page's example code

### DIFF
--- a/Language/Structure/Comparison Operators/equalTo.adoc
+++ b/Language/Structure/Comparison Operators/equalTo.adoc
@@ -48,7 +48,7 @@ x == y; // Ist true, wenn x gleich y ist und false, wenn x nicht gleich y ist
 
 [source,arduino]
 ----
-if (x==y) { // Prüft, ob x gleich y ist
+if (x == y) { // Prüft, ob x gleich y ist
   // Tue etwas nur dann, wenn das Vergleichsergebnis wahr ist
 }
 ----


### PR DESCRIPTION
As done in https://github.com/arduino/reference-en/commit/1ec8dbedf54b89881548ec8f9e563dff94de65a4