### PR TITLE
Fix formatting of && example code

### DIFF
--- a/Language/Structure/Boolean Operators/logicalAnd.adoc
+++ b/Language/Structure/Boolean Operators/logicalAnd.adoc
@@ -37,7 +37,7 @@ Dieser Operator kann innerhalb der Bedingung einer link:../../control-structure/
 [source,arduino]
 ----
 if (digitalRead(2) == HIGH && digitalRead(3) == HIGH) { // Wenn beide Werte HIGH sind
-    // Statement(s)
+  // Statement(s)
 }
 ----
 [%hardbreaks]


### PR DESCRIPTION
As done in https://github.com/arduino/reference-en/commit/1ec8dbedf54b89881548ec8f9e563dff94de65a4