### PR TITLE
Change UTF-8 BOM file encoding to UTF-8

### DIFF
--- a/Language/Variables/Data Types/String/Operators/comparison.adoc
+++ b/Language/Variables/Data Types/String/Operators/comparison.adoc
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "=="
 title_expanded: comparison
 categories: [ "Data Types" ]

--- a/Language/Variables/Data Types/String/Operators/elementAccess.adoc
+++ b/Language/Variables/Data Types/String/Operators/elementAccess.adoc
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "[] "
 title_expanded: element access
 categories: [ "Data Types" ]


### PR DESCRIPTION
Use consistent file encoding following the example of the sample reference pages.