### PR TITLE
Use the appropriate tutorial link to demonstrate INPUT_PULLUP

### DIFF
--- a/Language/Variables/Constants/constants.adoc
+++ b/Language/Variables/Constants/constants.adoc
@@ -113,7 +113,7 @@ Der ATmega-Mikrocontroller auf dem Arduino hat interne Pullup-Widerstände, auf 
 verwenden möchtest, kannst du `link:../../../functions/digital-io/pinmode[pinMode()]` mit der Konstante `INPUT_PULLUP` als Argument verwenden.
 [%hardbreaks]
 
-Siehe auch das http://arduino.cc/en/Tutorial/DigitalReadSerial[Digital Read Serial^]-Tutorial für weitere Informationen.
+Siehe auch das http://arduino.cc/en/Tutorial/InputPullupSerial[Input Pullup Serial^]-Tutorial für weitere Informationen.
 [%hardbreaks]
 
 Pins, die als `INPUT` oder `INPUT_PULLUP` definiert sind, können beschädigt oder zerstört werden, wenn diese Spannungen ausgesetzt werden, die negativ sind


### PR DESCRIPTION
The tutorial at the previous link uses an external pull-down resistor, so it is irrelevant to a discussion of INPUT_PULLDOWN.

The new tutorial is the one already in use in the English version of the Language Reference:
https://github.com/arduino/reference-en/blob/7ddbe22a5b313ec293cba015035dbc8c7ab5feec/Language/Variables/Constants/constants.adoc#L91

Partially fixes https://github.com/arduino/reference-de/issues/408 (in conjunction with https://github.com/arduino/reference-de/pull/409)

CC: @dhoxide